### PR TITLE
fix: ensure content is string in chatcmpl call method

### DIFF
--- a/pkg/provider/modelmgr/apis/chatcmpl.py
+++ b/pkg/provider/modelmgr/apis/chatcmpl.py
@@ -102,9 +102,14 @@ class OpenAIChatCompletions(api.LLMAPIRequester):
         messages: typing.List[llm_entities.Message],
         funcs: typing.List[tools_entities.LLMFunction] = None,
     ) -> llm_entities.Message:
-        req_messages = [  # req_messages 仅用于类内，外部同步由 query.messages 进行
-            m.dict(exclude_none=True) for m in messages
-        ]
+        req_messages = []
+        for m in messages:
+            msg_dict = m.dict(exclude_none=True)
+            if isinstance(msg_dict.get("content"), list):
+                # 确保content是字符串
+                msg_dict["content"] = "".join(
+                    [part["text"] for part in msg_dict["content"]])
+            req_messages.append(msg_dict)
 
         try:
             return await self._closure(req_messages, model, funcs)


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 确认 `chatcmpl` 方法中的 `content` 为字符串，解决与 `yi-large` 模型的兼容性问题。
修正[issue817](https://github.com/RockChinQ/QChatGPT/issues/817)

### 事务

- [x] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 暂无已知问题，但需要进一步测试以确保所有场景下的兼容性。